### PR TITLE
Fix duplicate symbols linkage failure

### DIFF
--- a/src/ldinternal.h
+++ b/src/ldinternal.h
@@ -51,7 +51,7 @@ void LDi_onstreameventput(struct LDClient *client, const char *data);
 void LDi_onstreameventpatch(struct LDClient *client, const char *data);
 void LDi_onstreameventdelete(struct LDClient *client, const char *data);
 
-void (*LDi_statuscallback)(int);
+extern void (*LDi_statuscallback)(int);
 
 void LDi_millisleep(int ms);
 /* must be called exactly once before rng is used */


### PR DESCRIPTION
Declaring the callback variable without `extern` defined this variable in every compilation unit where this header was included. As result on the link stage same symbol appears in multiple object files and triggers link conflict/failure.
Adding `extern` make compilation succeed
