### PR TITLE
Fixes a header initialization that was being compiled out

### DIFF
--- a/src/ldnet.c
+++ b/src/ldnet.c
@@ -782,13 +782,17 @@ LDi_sendevents(
     }
     headerlist = headertmp;
 
-    LD_ASSERT(
-        snprintf(
+    {
+        int len;
+        len = snprintf(
             payloadIdHeader,
             sizeof(payloadIdHeader),
             "%s%s",
             LD_PAYLOAD_ID_HEADER,
-            payloadUUID) == sizeof(payloadIdHeader) - 1);
+            payloadUUID);
+
+        LD_ASSERT(len == sizeof(payloadIdHeader) - 1);
+    }
 
 #undef LD_PAYLOAD_ID_HEADER
 


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

I noticed that this was being printed every few minutes:

```
[launchdarkly/src/ldthreads.c, 141] sending events failed deleting event batch
```

After enabling curl's verbose mode. I noticed that LD was responding with 400.

It turned out this header is being initialized inside an `LD_ASSERT` which, when compiled out, takes with it the initialization.

**Describe the solution you've provided**

Separate the assertion from the initialization

**Describe alternatives you've considered**

N/A

