### PR TITLE
Log curl's error code if curl_easy_perform fails.

### DIFF
--- a/src/ldnet.c
+++ b/src/ldnet.c
@@ -524,6 +524,7 @@ LDi_readstream(
         LD_LOG_1(LD_LOG_DEBUG, "curl response code %d", (int)response_code);
         *response = response_code;
     } else {
+        LD_LOG_1(LD_LOG_DEBUG, "curl_easy_perform returned error code %d", (int)res);
         *response = res;
     }
 


### PR DESCRIPTION
**Requirements**

- [x ] I have added test coverage for new or changed functionality
- [x ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x ] I have validated my changes against all supported platform versions

**Related issues**

We've run into issues with SSL certificate errors that took longer to track down than they should have because the underlying `CURLcode` was obscured.  `LDi_bgfeaturestreamer` attempts to interpret these responses as http codes and log things in plain English, but it doesn't cover the range of curl codes, instead just logging all of them as `streaming failed with recoverable error, backing off`.

**Describe the solution you've provided**

Any failure from `curl_easy_perform` in `LDi_readstream` will log the raw `CURLcode` to the debug log stream.

**Describe alternatives you've considered**

`LDi_bgfeaturestreamer` could be modified to interpret these codes, but that function looks like it's attempting to log higher level issues and http response codes in plain English.

**Additional context**

