### PR TITLE
Implement `LDClientRegisterFeatureFlagListenerUserData`

### DIFF
--- a/cpp/api.cpp
+++ b/cpp/api.cpp
@@ -206,3 +206,17 @@ LDClientCPP::unregisterFeatureFlagListener(const std::string &name,
 {
     LDClientUnregisterFeatureFlagListener(this->client, name.c_str(), fn);
 }
+
+bool
+LDClientCPP::registerFeatureFlagListenerUserData(const std::string &name,
+    LDlistenerUserDatafn fn, void *const userdata)
+{
+    return LDClientRegisterFeatureFlagListenerUserData(this->client, name.c_str(), fn, userdata);
+}
+
+void
+LDClientCPP::unregisterFeatureFlagListenerUserData(const std::string &name,
+    LDlistenerUserDatafn fn)
+{
+    LDClientUnregisterFeatureFlagListenerUserData(this->client, name.c_str(), fn);
+}

--- a/cpp/include/launchdarkly/api.hpp
+++ b/cpp/include/launchdarkly/api.hpp
@@ -142,6 +142,12 @@ class LD_EXPORT(LDClientCPP) {
 
         /** @brief Unregister a callback registered with `LDClientRegisterFeatureFlagListener`. */
         void unregisterFeatureFlagListener(const std::string &name, LDlistenerfn fn);
+
+        /** @brief Register a callback for when a flag is updated. */
+        bool registerFeatureFlagListenerUserData(const std::string &name, LDlistenerUserDatafn fn, void *const userData);
+
+        /** @brief Unregister a callback registered with `LDClientRegisterFeatureFlagListener`. */
+        void unregisterFeatureFlagListenerUserData(const std::string &name, LDlistenerUserDatafn fn);
     private:
         struct LDClient *client;
 };

--- a/include/launchdarkly/client.h
+++ b/include/launchdarkly/client.h
@@ -275,3 +275,25 @@ LDClientUnregisterFeatureFlagListener(
     struct LDClient *const client,
     const char *const      flagKey,
     LDlistenerfn           listener);
+
+/** @brief Feature flag listener callback type with user data. Callbacks are
+ * not reentrant safe.
+ *
+ * Status 0 for new or updated, 1 for deleted. */
+typedef void (*LDlistenerUserDatafn)(const char *const flagKey, const int status, void *const userData);
+
+/** @brief Register a callback that takes a user data argument for when a flag is updated. */
+LD_EXPORT(LDBoolean)
+LDClientRegisterFeatureFlagListenerUserData(
+    struct LDClient *const client,
+    const char *const      flagKey,
+    LDlistenerUserDatafn   listener,
+    void *const            userData);
+
+/** @brief Unregister a callback registered with
+ * `LDClientRegisterFeatureFlagListenerUserData` */
+LD_EXPORT(void)
+LDClientUnregisterFeatureFlagListenerUserData(
+    struct LDClient *const client,
+    const char *const      flagKey,
+    LDlistenerUserDatafn   listener);

--- a/src/client.c
+++ b/src/client.c
@@ -1325,6 +1325,76 @@ LDClientUnregisterFeatureFlagListener(
     LDi_storeUnregisterListener(&client->store, key, fn);
 }
 
+LDBoolean
+LDClientRegisterFeatureFlagListenerUserData(
+    struct LDClient *const client, const char *const key, LDlistenerUserDatafn fn, void *const userData)
+{
+    LD_ASSERT_API(client);
+    LD_ASSERT_API(key);
+    LD_ASSERT_API(fn);
+
+#ifdef LAUNCHDARKLY_DEFENSIVE
+    if (client == NULL) {
+        LD_LOG(
+            LD_LOG_WARNING, "LDClientRegisterFeatureFlagListenerUserData NULL client");
+
+        return LDBooleanFalse;
+    }
+
+    if (key == NULL) {
+        LD_LOG(LD_LOG_WARNING, "LDClientRegisterFeatureFlagListenerUserData NULL key");
+
+        return LDBooleanFalse;
+    }
+
+    if (fn == NULL) {
+        LD_LOG(
+            LD_LOG_WARNING,
+            "LDClientRegisterFeatureFlagListenerUserData NULL listener");
+
+        return LDBooleanFalse;
+    }
+#endif
+
+    return LDi_storeRegisterListenerUserData(&client->store, key, fn, userData);
+}
+
+void
+LDClientUnregisterFeatureFlagListenerUserData(
+    struct LDClient *const client, const char *const key, LDlistenerUserDatafn fn)
+{
+    LD_ASSERT_API(client);
+    LD_ASSERT_API(key);
+    LD_ASSERT_API(fn);
+
+#ifdef LAUNCHDARKLY_DEFENSIVE
+    if (client == NULL) {
+        LD_LOG(
+            LD_LOG_WARNING,
+            "LDClientUnregisterFeatureFlagListener NULL client");
+
+        return;
+    }
+
+    if (key == NULL) {
+        LD_LOG(
+            LD_LOG_WARNING, "LDClientUnregisterFeatureFlagListener NULL key");
+
+        return;
+    }
+
+    if (fn == NULL) {
+        LD_LOG(
+            LD_LOG_WARNING,
+            "LDClientUnregisterFeatureFlagListener NULL listener");
+
+        return;
+    }
+#endif
+
+    LDi_storeUnregisterListenerUserData(&client->store, key, fn);
+}
+
 void
 LDi_updatestatus(struct LDClient *const client, const LDStatus status)
 {

--- a/src/flag_change_listener.c
+++ b/src/flag_change_listener.c
@@ -4,11 +4,23 @@
 
 #include <string.h>
 
+enum ChangeListenerType {
+    WithoutUserData,
+    WithUserData
+};
+
 struct ChangeListener {
     /* Owned flag key; must be freed. */
     char *flag;
-    /* User-provided callback. */
-    LDlistenerfn callback;
+    /* Whether the callback has user data associated with it. */
+    enum ChangeListenerType type;
+    /* User-provided callback. The type member indicates which union member is set. */
+    union {
+        LDlistenerfn withoutUserData;
+        LDlistenerUserDatafn withUserData;
+    } callback;
+    /* User data to be passed to the callback or NULL. */
+    void * userData;
     /* Used by utlist.h macros. */
     struct ChangeListener *next;
 };
@@ -21,8 +33,32 @@ newListener(const char* flag, LDlistenerfn callback) {
         return LDBooleanFalse;
     }
 
-    listener->callback = callback;
+    listener->type = WithoutUserData;
+    listener->callback.withoutUserData = callback;
     listener->flag = NULL;
+    listener->userData = NULL;
+    listener->next = NULL;
+
+    if (!(listener->flag = LDStrDup(flag))) {
+        LDFree(listener);
+        return NULL;
+    }
+
+    return listener;
+}
+
+static struct ChangeListener *
+newListenerUserData(const char* flag, LDlistenerUserDatafn callback, void *const userData) {
+    struct ChangeListener *listener = NULL;
+
+    if (!(listener = LDAlloc(sizeof(struct ChangeListener)))) {
+        return LDBooleanFalse;
+    }
+
+    listener->type = WithUserData;
+    listener->callback.withUserData = callback;
+    listener->flag = NULL;
+    listener->userData = userData;
     listener->next = NULL;
 
     if (!(listener->flag = LDStrDup(flag))) {
@@ -49,13 +85,23 @@ flagcmp(struct ChangeListener *a, struct ChangeListener *b) {
         return cmp;
     }
 
+    /* If one listener has user data and the other doesn't, they are unequal. */
+    if (a->type != b->type) {
+        return a->type - b->type > 0 ? 1 : -1;
+    }
+
     /* If the listeners have the same flag & callback, they are equal. */
-    if (a->callback == b->callback) {
+    if (a->type == WithUserData ? a->callback.withUserData == b->callback.withUserData : a->callback.withoutUserData == b->callback.withoutUserData) {
         return 0;
     }
 
+    /* If the listeners have different user data, they're not equal. */
+    if (a->type == WithUserData && a->userData != b->userData) {
+        return a->userData > b->userData ? 1 : -1;
+    }
+
     /* Otherwise, sort by the callback address to provide something stable.*/
-    if ((unsigned long) a->callback > (unsigned long) b->callback) {
+    if (a->type == WithUserData ? ((unsigned long) a->callback.withUserData > (unsigned long) b->callback.withUserData) : ((unsigned long) a->callback.withoutUserData > (unsigned long) b->callback.withoutUserData)) {
         return 1;
     }
     return -1;
@@ -114,7 +160,7 @@ LDi_listenerRemove(struct ChangeListener** listeners, const char* flag, LDlisten
     listener = NULL;
 
     LL_FOREACH_SAFE(*listeners, listener, tmp) {
-        if (strcmp(listener->flag, flag) == 0 && listener->callback == callback) {
+        if (strcmp(listener->flag, flag) == 0 && listener->type == WithoutUserData && listener->callback.withoutUserData == callback) {
             LL_DELETE(*listeners, listener);
             freeListener(listener);
 
@@ -123,6 +169,45 @@ LDi_listenerRemove(struct ChangeListener** listeners, const char* flag, LDlisten
     }
 }
 
+LDBoolean
+LDi_listenerUserDataAdd(struct ChangeListener** listeners, const char* flag, LDlistenerUserDatafn callback, void* const userData) {
+    struct ChangeListener *new, *existing;
+
+    new = NULL;
+    existing = NULL;
+
+    if (!(new = newListenerUserData(flag, callback, userData))) {
+        return LDBooleanFalse;
+    }
+
+    LL_SEARCH(*listeners, existing, new, flagcmp);
+
+    /* Ensure uniqueness of (flag, function pointer) combo. */
+    if (existing) {
+        freeListener(new);
+        return LDBooleanTrue;
+    }
+
+    LL_PREPEND(*listeners, new);
+    return LDBooleanTrue;
+}
+
+void
+LDi_listenerUserDataRemove(struct ChangeListener** listeners, const char* flag, LDlistenerUserDatafn callback) {
+    struct ChangeListener *tmp, *listener;
+
+    tmp = NULL;
+    listener = NULL;
+
+    LL_FOREACH_SAFE(*listeners, listener, tmp) {
+        if (strcmp(listener->flag, flag) == 0 && listener->type == WithUserData && listener->callback.withUserData == callback) {
+            LL_DELETE(*listeners, listener);
+            freeListener(listener);
+
+            break; /* early out, since listenerInsert disallows duplicates */
+        }
+    }
+}
 
 void
 LDi_listenersDispatch(struct ChangeListener* listeners, const char *flag, LDBoolean status) {
@@ -133,7 +218,11 @@ LDi_listenersDispatch(struct ChangeListener* listeners, const char *flag, LDBool
 
     LL_FOREACH_SAFE(listeners, listener, tmp) {
         if (strcmp(listener->flag, flag) == 0) {
-            listener->callback(flag, status);
+            if (listener->type == WithUserData) {
+                listener->callback.withUserData(flag, status, listener->userData);
+            } else {
+                listener->callback.withoutUserData(flag, status);
+            }
         }
     }
 }

--- a/src/flag_change_listener.h
+++ b/src/flag_change_listener.h
@@ -31,6 +31,16 @@ LDi_listenerAdd(struct ChangeListener** listeners, const char* flag, LDlistenerf
 void
 LDi_listenerRemove(struct ChangeListener** listeners, const char* flag, LDlistenerfn callback);
 
+/* Insert a new listener with user data.
+ * If the combination of (flag, function pointer) already exists, no new listener is created.
+ * If allocation fails, returns false. */
+LDBoolean
+LDi_listenerUserDataAdd(struct ChangeListener** listeners, const char* flag, LDlistenerUserDatafn callback, void* const userData);
+
+/* Deletes a listener with user data from the list. */
+void
+LDi_listenerUserDataRemove(struct ChangeListener** listeners, const char* flag, LDlistenerUserDatafn callback);
+
 /* Dispatches an event for a given flag to all registered listeners. */
 void
 LDi_listenersDispatch(struct ChangeListener* listeners, const char *flag, LDBoolean status);

--- a/src/store.c
+++ b/src/store.c
@@ -361,3 +361,34 @@ LDi_storeUnregisterListener(struct LDStore *const store, const char *const flagK
     LDi_listenerRemove(&store->listeners, flagKey, op);
     LDi_rwlock_wrunlock(&store->lock);
 }
+
+/* Registers a listener callback for a given flag, returning true on success or if the combination of flag key and listener
+ * callback is already registered. */
+LDBoolean
+LDi_storeRegisterListenerUserData(struct LDStore *const store, const char *const flagKey, LDlistenerUserDatafn op, void *const userData)
+{
+    LDBoolean status;
+
+    LD_ASSERT(store);
+    LD_ASSERT(flagKey);
+    LD_ASSERT(op);
+
+    LDi_rwlock_wrlock(&store->lock);
+    status = LDi_listenerUserDataAdd(&store->listeners, flagKey, op, userData);
+    LDi_rwlock_wrunlock(&store->lock);
+
+    return status;
+}
+
+void
+LDi_storeUnregisterListenerUserData(struct LDStore *const store, const char *const flagKey, LDlistenerUserDatafn op)
+{
+
+    LD_ASSERT(store);
+    LD_ASSERT(flagKey);
+    LD_ASSERT(op);
+
+    LDi_rwlock_wrlock(&store->lock);
+    LDi_listenerUserDataRemove(&store->listeners, flagKey, op);
+    LDi_rwlock_wrunlock(&store->lock);
+}

--- a/src/store.h
+++ b/src/store.h
@@ -64,5 +64,13 @@ void
 LDi_storeUnregisterListener(
     struct LDStore *const store, const char *const flagKey, LDlistenerfn op);
 
+LDBoolean
+LDi_storeRegisterListenerUserData(
+    struct LDStore *const store, const char *const flagKey, LDlistenerUserDatafn op, void *const userData);
+
+void
+LDi_storeUnregisterListenerUserData(
+    struct LDStore *const store, const char *const flagKey, LDlistenerUserDatafn op);
+
 void
 LDi_storeFreeFlags(struct LDStore *const store);

--- a/tests/test-hooks.cpp
+++ b/tests/test-hooks.cpp
@@ -13,10 +13,18 @@ class HooksFixture : public CommonFixture {
 };
 
 static int callCountUpsert = 0;
+static int callCountUpsertUserData = 0;
+static int intUserData = 123;
 
 void
 hookUpsert(const char *const name, const int change) {
     callCountUpsert++;
+}
+
+void
+hookUpsertUserData(const char *const name, const int change, void *const userData) {
+    callCountUpsertUserData++;
+    ASSERT_EQ(intUserData, *(int *)userData);
 }
 
 TEST_F(HooksFixture, BasicHookUpsert) {
@@ -26,6 +34,7 @@ TEST_F(HooksFixture, BasicHookUpsert) {
     ASSERT_TRUE(LDi_storeInitialize(&store));
 
     ASSERT_TRUE(LDi_storeRegisterListener(&store, "test", hookUpsert));
+    ASSERT_TRUE(LDi_storeRegisterListenerUserData(&store, "test", hookUpsertUserData, &intUserData));
 
     flag.key = LDStrDup("test");
     flag.value = LDNewBool(LDBooleanTrue);
@@ -43,15 +52,23 @@ TEST_F(HooksFixture, BasicHookUpsert) {
     ASSERT_TRUE(LDi_storeUpsert(&store, flag));
 
     ASSERT_EQ(callCountUpsert, 1);
+    ASSERT_EQ(callCountUpsertUserData, 1);
 
     LDi_storeDestroy(&store);
 }
 
 static int callCountPut = 0;
+static int callCountPutUserData = 0;
 
 void
 hookPut(const char *const name, const int change) {
     callCountPut++;
+}
+
+void
+hookPutUserData(const char *const name, const int change, void *const userData) {
+    callCountPutUserData++;
+    ASSERT_EQ(intUserData, *(int *)userData);
 }
 
 TEST_F(HooksFixture, BasicHookPut) {
@@ -62,6 +79,7 @@ TEST_F(HooksFixture, BasicHookPut) {
 
     ASSERT_TRUE(LDi_storeInitialize(&store));
     ASSERT_TRUE(LDi_storeRegisterListener(&store, "test", hookPut));
+    ASSERT_TRUE(LDi_storeRegisterListenerUserData(&store, "test", hookPutUserData, &intUserData));
 
     flag->key = LDStrDup("test");
     flag->value = LDNewBool(LDBooleanTrue);
@@ -79,6 +97,7 @@ TEST_F(HooksFixture, BasicHookPut) {
     ASSERT_TRUE(LDi_storePut(&store, flag, 1));
 
     ASSERT_EQ(callCountPut, 1);
+    ASSERT_EQ(callCountPutUserData, 1);
 
     LDi_storeDestroy(&store);
 }


### PR DESCRIPTION
This fixes #84.  In this PR we're adding a version of the LaunchDarkly
flag change listener APIs that allows the caller to pass a `void *`
user data argument, which can be used similar to a closure in higher
level languages.  Also implement the C++ version of this API:
`registerFeatureFlagListenerUserData`.

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions
  I tested my changes on Linux.  Don't have a Windows machine handy for testing there at the moment unfortunately.

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.
https://github.com/launchdarkly/c-client-sdk/issues/84

The answer to all questions below has been provided in that issue.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
