### PR TITLE
Switch back to CircleCI executor for Linux release

### DIFF
--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -7,7 +7,7 @@ repo:
 jobs:
   - circleCI:
       linux: 
-        image: ldcircleci/ld-c-sdk-ubuntu:2  # defined in sdks-ci-docker project
+        image: ldcircleci/ld-c-sdk-ubuntu:5  # defined in sdks-ci-docker project
       # Needed to allow AWS authentication to succeed using circleCI job (an empty context will suffice; this one
       # exists specifically for that purpose.)
       context: circleci-oidc-auth

--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -5,8 +5,12 @@ repo:
   private: c-client-sdk-private
 
 jobs:
-  - docker:
-      image: ldcircleci/ld-c-sdk-ubuntu:2  # defined in sdks-ci-docker project
+  - circleCI:
+      linux: 
+        image: ldcircleci/ld-c-sdk-ubuntu:2  # defined in sdks-ci-docker project
+      # Needed to allow AWS authentication to succeed using circleCI job (an empty context will suffice; this one
+      # exists specifically for that purpose.)
+      context: circleci-oidc-auth
     env:
       LD_LIBRARY_FILE_PREFIX: linux-gcc-64bit
   - circleCI:

--- a/.ldrelease/linux-build-docs.sh
+++ b/.ldrelease/linux-build-docs.sh
@@ -8,4 +8,4 @@ PROJECT_DIR=$(pwd)
 
 doxygen
 
-cp -r ${PROJECT_DIR}/docs/build/html/* ${LD_RELEASE_DOCS_DIR}
+cp -r "${PROJECT_DIR}"/docs/build/html/* "${LD_RELEASE_DOCS_DIR}"


### PR DESCRIPTION
Reverts back to earlier state where CircleCI job is used for Linux build.

Switching to the default Docker executor used by Releaser didn't _quite_ work, as it doesn't have the packages necessary to do a clean documentation build. 

Additionally, that change - although not a huge deal - did slow down the release process, since the Linux job couldn't run concurrently as is the case when using CircleCI jobs.

The original reason for switching was because the `curl` dependency was already present in Releaser's default image. I'm ~updating~ (done) ld-c-sdk-ubuntu to [contain](https://github.com/launchdarkly/sdks-ci-docker/pull/19) that.