### PR TITLE
Switch back to CircleCI executor for Linux release (#97)

### DIFF
--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -5,8 +5,12 @@ repo:
   private: c-client-sdk-private
 
 jobs:
-  - docker:
-      image: ldcircleci/ld-c-sdk-ubuntu:2  # defined in sdks-ci-docker project
+  - circleCI:
+      linux: 
+        image: ldcircleci/ld-c-sdk-ubuntu:5  # defined in sdks-ci-docker project
+      # Needed to allow AWS authentication to succeed using circleCI job (an empty context will suffice; this one
+      # exists specifically for that purpose.)
+      context: circleci-oidc-auth
     env:
       LD_LIBRARY_FILE_PREFIX: linux-gcc-64bit
   - circleCI:

--- a/.ldrelease/linux-build-docs.sh
+++ b/.ldrelease/linux-build-docs.sh
@@ -8,4 +8,4 @@ PROJECT_DIR=$(pwd)
 
 doxygen
 
-cp -r ${PROJECT_DIR}/docs/build/html/* ${LD_RELEASE_DOCS_DIR}
+cp -r "${PROJECT_DIR}"/docs/build/html/* "${LD_RELEASE_DOCS_DIR}"


### PR DESCRIPTION
Pulls over the Releaser changes from public. 

(Note to self: this is probably what I should be doing for all Releaser changes, not the other way around.)